### PR TITLE
Add new url display tool

### DIFF
--- a/url
+++ b/url
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -u
+
+echo "Finding network ports for the container named 'web'"
+
+port=$(docker port web 80 | cut -d: -f2)
+
+if which docker-machine >/dev/null 2>&1
+then
+  echo "Found \"docker-machine\", guessing you're not on Linux. Getting ip address from VM." >&2
+  addr=$(docker-machine ip)
+else
+  echo "No \"docker-machine\" found, guessing you're on Linux. Using localhost." >&2
+  addr="127.0.0.1"
+fi
+
+echo "Canvas address: http://${addr}:${port}/"

--- a/url
+++ b/url
@@ -7,11 +7,12 @@ port=$(docker port web 80 | cut -d: -f2)
 
 if which docker-machine >/dev/null 2>&1
 then
-  echo "Found \"docker-machine\", guessing you're not on Linux. Getting ip address from VM." >&2
+  echo "Found \"docker-machine\", guessing you're not on Linux. Getting ip address from VM."
   addr=$(docker-machine ip)
 else
-  echo "No \"docker-machine\" found, guessing you're on Linux. Using localhost." >&2
+  echo "No \"docker-machine\" found, guessing you're on Linux. Using localhost."
   addr="127.0.0.1"
 fi
 
+echo ""
 echo "Canvas address: http://${addr}:${port}/"


### PR DESCRIPTION
`b2d` depends on `boot2docker`. `url` reimplements `b2d url` (sorta), but with Docker Toolbox' `docker-machine` rather than `boot2docker`.
